### PR TITLE
Wind reached front line

### DIFF
--- a/BeforeDayBegins.md
+++ b/BeforeDayBegins.md
@@ -13,8 +13,8 @@ _TargetLang_: _en_
 From here and from afar  
 and walks of mountain ash  
 where forests burned  
-and wind gave way to  
-battle cries  
+and wind reached front line
+night and cold
 Where fields of crops untouched  
 Where fruit have rotten black  
 Day is nigh  


### PR DESCRIPTION
Mimo swej poetyckości "wind gave way to battle cries" było średnio śpiewalne, bo po "ba-" jest krótka pauza. Szkoda, bo jako wiersz byłoby to świetne tłumaczenie. Ale tutaj raz, że słowo jest przerwane, a dwa, że marnujemy akcent (bo to co przed pauzą siłą rzeczy będzie akcentowane) na coś, co nie jest słowem.  Poza tym (subiektywnie) podoba mi się wspomnienie "frontu" bez jeszcze wprost wspomnienia wojny (które jest później). Dodatkowo "burnt" się ~rymuje z "front" się ~rymuje z "cold".  

Opcjonalnie może być też "hit front line" lub "met front line".

cc @k3rnelj